### PR TITLE
chore: add migrations to the docker compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ http://localhost:8080/internal/api/resolve?subject=ngerakines.me&subject=mattie.
 
 1. Install `pdm install` (Note that `pdm install` may require `sudo apt install -y clang libpq-dev python3-dev build-essential` to build for postgres requirements!)
 2. Populate signing keys: `OUT=$(pdm run aiputil gen-jwk)` and then `echo "{\"keys\":[$OUT]}" > signing_keys.json`
-3. Add `EXTERNAL_HOSTNAME: your-host` to your docker compose file[1].
-4. `docker compose build && docker compose up`
-5. Then navigate to your host at the path /auth/atproto. This is your login page!
-6. Note that in the config you can change colors, text, display image, and default post-login destination. You can *also* forward the response to *any* URL with a ?destination={URL} parameter on the sign-in page
+3. Add `EXTERNAL_HOSTNAME: your-host` to the `x-environment` section of the docker compose file[1].
+4. Set active signing keys in the `x-environment` section of the docker compose file: `ACTIVE_SIGNING_KEYS='["{KEY_ID}"]'` where `{KEY_ID}` is the `"kid"` value in your generated `signing_keys.json` file.
+5. `docker compose up --build`
+6. Then navigate to your host at the path /auth/atproto. This is your login page!
+7. Note that in the config you can change colors, text, display image, and default post-login destination. You can *also* forward the response to *any* URL with a ?destination={URL} parameter on the sign-in page
 
 [1]: This must match the URL this service is running on. For development purposes, you can install ngrok then run `ngrok http 8080` which will forward traffic on https to a specified ngrok URL. You would then take that host (without https) and put it in your docker compose before starting up.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,21 @@
+version: "3.8"
+
+# Change AIP env vars here
+x-environment: &aip-environment
+  DATABASE_URL: postgresql+asyncpg://aip:aip_password@db:5432/aip_db
+  VALKEY_URL: redis://valkey:6379/0
+  DEBUG: "true"
+  WORKER_ID: "dev1"
+  ACTIVE_SIGNING_KEYS: '["change-this-value"]'
+  JSON_WEB_KEYS: /app/signing_keys.json
+  # Add your hostname here
+  # EXTERNAL_HOSTNAME: "myhost.local"
+
+# Change AIP volume mounts here
+x-volumes: &aip-volumes
+  - .:/app # Mount local directory to container
+  - /app/.venv # Preserve virtual environment
+
 services:
   db:
     image: postgres:17
@@ -36,11 +54,11 @@ services:
     volumes:
       - ./telegraf.conf:/etc/telegraf/telegraf.conf
 
-  aip:
+  aip_db_migrations:
     build: .
-    container_name: aip_service
-    command: ["pdm", "run", "aipserver"]
-    restart: always
+    container_name: aip_db_migrations
+    command: ["pdm", "run", "alembic", "upgrade", "head"]
+    restart: no
     depends_on:
       db:
         condition: service_healthy
@@ -48,23 +66,27 @@ services:
         condition: service_started
       telegraf:
         condition: service_started
-    environment:
-      DATABASE_URL: postgresql+asyncpg://aip:aip_password@db:5432/aip_db
-      VALKEY_URL: redis://valkey:6379/0
-      DEBUG: "true"
-      WORKER_ID: "dev1"
-      ACTIVE_SIGNING_KEYS: '["01JNEKAHBPFQYJX3RS7HH7W2RY"]'
-      JSON_WEB_KEYS: /app/signing_keys.json
+    environment: *aip-environment
+    volumes: *aip-volumes
+
+  aip:
+    build: .
+    container_name: aip_service
+    command: ["pdm", "run", "aipserver"]
+    restart: always
+    depends_on:
+      aip_db_migrations:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      valkey:
+        condition: service_started
+      telegraf:
+        condition: service_started
+    environment: *aip-environment
     ports:
       - "8080:8080"
-      - "5100:5100"
-    volumes:
-      - .:/app  # Mount local directory to container
-      - /app/.venv  # Preserve virtual environment
-    # TODO: move to Tilt-based debugging
-    # volumes:
-    #   - .:/app
-    #   - /app/.venv
+    volumes: *aip-volumes
 
 volumes:
   aip_db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,11 @@ x-environment: &aip-environment
   VALKEY_URL: redis://valkey:6379/0
   DEBUG: "true"
   WORKER_ID: "dev1"
+  # Add your generated key id here
   ACTIVE_SIGNING_KEYS: '["change-this-value"]'
   JSON_WEB_KEYS: /app/signing_keys.json
   # Add your hostname here
-  # EXTERNAL_HOSTNAME: "myhost.local"
+  EXTERNAL_HOSTNAME: "change.this.value"
 
 # Change AIP volume mounts here
 x-volumes: &aip-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-environment: &aip-environment
   # Add your hostname here
   EXTERNAL_HOSTNAME: "change.this.value"
 
-# Change AIP volume mounts here
+# AIP Volume Mounts
 x-volumes: &aip-volumes
   - .:/app # Mount local directory to container
   - /app/.venv # Preserve virtual environment


### PR DESCRIPTION
This PR includes some improved instructions in the README from running via docker-compose, based on feedback from the discord. It also adds a migration container that runs before the AIP container boots. 