### PR TITLE
Add a random token generator fn

### DIFF
--- a/examples/simple-website/src/main.rs
+++ b/examples/simple-website/src/main.rs
@@ -278,7 +278,10 @@ fn generate_pkce() -> (String, String) {
     use sha2::{Digest, Sha256};
 
     // Generate code verifier (43-128 characters, URL-safe)
-    let code_verifier = generate_from_alphabet("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~", 43);
+    let code_verifier = generate_from_alphabet(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
+        43,
+    );
 
     // Generate code challenge (SHA256 hash of verifier, base64url encoded)
     let mut hasher = Sha256::new();
@@ -291,7 +294,10 @@ fn generate_pkce() -> (String, String) {
 
 /// Generate random state parameter
 fn generate_state() -> String {
-    generate_from_alphabet("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 32)
+    generate_from_alphabet(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+        32,
+    )
 }
 
 /// Register a dynamic OAuth client with the AIP server (RFC 7591)


### PR DESCRIPTION
The existing code in the `simple-website` example manually builds up tokens in a couple places, with a type cast and indexing in the process.

This change extracts token generation to a helper function, updates the types to avoid casting, and refactors it to use `choose_multiple` from rand0.8's `SliceRandom` to avoid direct indexing.

Ultimately it's only a bit more than a cosmetic change, so feel free to close/reject if you prefer keeping a flatter style with fewer helper functions.

---

Note that `rand 0.9` has been out since January and it might be worth updating. From uses I've spotted, AIP is only affected by names changing (like `rand::thread_rng()` becomes just `rand::rng()`), so it's pretty mechanical to update. I'd be happy to follow up with that if you want!