### PR TITLE
feat: add tower-http tracing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.5", features = ["fs", "cors"] }
+tower-http = { version = "0.5", features = ["fs", "cors", "trace"] }
 reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "system-proxy", "json", "rustls-tls"] }
 async-trait = "0.1"
 http = "1.0"

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -4,7 +4,7 @@ use axum::{
     Router, middleware,
     routing::{get, post},
 };
-use tower_http::{cors::CorsLayer, services::ServeDir};
+use tower_http::{cors::CorsLayer, services::ServeDir, trace::TraceLayer};
 
 use super::{
     context::AppState,
@@ -121,6 +121,7 @@ pub fn build_router(ctx: AppState) -> Router {
         )
         .nest_service("/static", ServeDir::new(&ctx.config.http_static_path))
         .layer(cors)
+        .layer(TraceLayer::new_for_http())
         .with_state(ctx)
 }
 


### PR DESCRIPTION
  Noticed the tower-http trace feature wasn't enabled in the cargo.toml but used in the example configuration.md. This should fix it!
  
  ## Summary
  - Add tower-http trace feature and TraceLayer middleware for
  HTTP request/response logging
  - Enables structured logging of incoming HTTP requests and
  responses

  ## Usage

  To enable HTTP request tracing, set the following environment
  variable:

  ```bash
  RUST_LOG=tower_http=debug

  This will log detailed information about incoming HTTP requests
  including:
  - Request method and URI
  - Response status codes
  - Request/response timing
  - Headers (configurable)