### PR TITLE
Use PAT in release creation pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: create_release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DISPATCH_GH_TOKEN }}
         run: |-
           gh release create ${{ env.VERSION_TAG }} -t ${{ env.VERSION_TAG }} --generate-notes
 


### PR DESCRIPTION
The default GHA token uses `contents:write` which is only scoped to tag the HEAD commit, and thus will fail when attempting to create a release after merging forks. Here swapping the default for the token already in use in the repo dispatch. The downside is that all releases will be created by me...this will go away in the new workflow. 