### PR TITLE
Change base image to rust:1.89-slim-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.89-slim AS builder
+FROM rust:1.89-slim-bookworm AS builder
 
 # Install required system dependencies for building
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` for the build stage to improve compatibility and security.