### PR TITLE
feat: add support for repo:* wildcard scope in OAuth validation

### DIFF
--- a/src/http/handler_par.rs
+++ b/src/http/handler_par.rs
@@ -214,7 +214,14 @@ fn validate_and_convert_par_request(
             crate::oauth::types::parse_scope(&config.oauth_supported_scopes.as_strings().join(" "));
 
         // First, validate against server's supported scopes
-        if !requested_scopes.is_subset(&supported_scopes) {
+        let supported_scope_strings = config.oauth_supported_scopes.as_strings();
+        let all_scopes_supported = requested_scopes.iter().all(|requested| {
+            supported_scopes.contains(requested) ||
+                // Support the special repo:* wildcard for any repo scope
+                (supported_scope_strings.contains(&"repo:*".to_string()) && requested.starts_with("repo:"))
+        });
+
+        if !all_scopes_supported {
             return Err(OAuthError::InvalidScope(
                 "One or more requested scopes are not supported by this server".to_string(),
             ));


### PR DESCRIPTION
Allows repo:* as a wildcard scope that matches any repo-prefixed scope.

For example, setting supported scopes to "atproto repo:*" allows "atproto repo:com.example.post repo.com.example.comment"

- Modified scope validation in client registration, PAR, and OAuth authorize endpoints
- Added tests for wildcard scope validation
- Maintains backward compatibility with explicit scope lists