### PR TITLE
fix: bind to [::] for IPv6 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,149 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}
+  ATCR_IMAGE: atcr.io/${{ secrets.ATCR_NAMESPACE }}/aip
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to ATCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: atcr.io
+          username: ${{ secrets.ATCR_USERNAME }}
+          password: ${{ secrets.ATCR_PASSWORD }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.ATCR_IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=build-${{ matrix.platform }}
+          cache-to: type=gha,scope=build-${{ matrix.platform }},mode=max
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.ATCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to ATCR
+        uses: docker/login-action@v3
+        with:
+          registry: atcr.io
+          username: ${{ secrets.ATCR_USERNAME }}
+          password: ${{ secrets.ATCR_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.ATCR_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+
+      - name: Create ATCR manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Extract only ATCR tags from metadata
+          ATCR_TAGS=$(jq -cr '.tags | map(select(startswith("atcr.io"))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -n "$ATCR_TAGS" ]; then
+            docker buildx imagetools create $ATCR_TAGS \
+              $(printf '${{ env.ATCR_IMAGE }}@sha256:%s ' *)
+          fi
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/migrations/postgres/015_create_delegate_access.sql
+++ b/migrations/postgres/015_create_delegate_access.sql
@@ -1,0 +1,10 @@
+-- Delegate access table: allows one DID to act on behalf of another
+CREATE TABLE IF NOT EXISTS delegate_access (
+    owner_did TEXT NOT NULL,
+    delegate_did TEXT NOT NULL,
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (owner_did, delegate_did)
+);
+
+CREATE INDEX IF NOT EXISTS idx_delegate_access_owner ON delegate_access (owner_did);
+CREATE INDEX IF NOT EXISTS idx_delegate_access_delegate ON delegate_access (delegate_did);

--- a/migrations/sqlite/027_create_delegate_access.sql
+++ b/migrations/sqlite/027_create_delegate_access.sql
@@ -1,0 +1,10 @@
+-- Delegate access table: allows one DID to act on behalf of another
+CREATE TABLE IF NOT EXISTS delegate_access (
+    owner_did TEXT NOT NULL,
+    delegate_did TEXT NOT NULL,
+    granted_at TEXT NOT NULL,
+    PRIMARY KEY (owner_did, delegate_did)
+);
+
+CREATE INDEX IF NOT EXISTS idx_delegate_access_owner ON delegate_access (owner_did);
+CREATE INDEX IF NOT EXISTS idx_delegate_access_delegate ON delegate_access (delegate_did);

--- a/src/bin/aip.rs
+++ b/src/bin/aip.rs
@@ -319,7 +319,7 @@ async fn main() -> Result<()> {
         let http_port = *inner_config.http_port.as_ref();
         let inner_token = token.clone();
         tracker.spawn(async move {
-            let bind_address = format!("0.0.0.0:{http_port}");
+            let bind_address = format!("[::]:{http_port}");
             tracing::info!("Starting server on {bind_address}");
             let listener = TcpListener::bind(&bind_address).await.unwrap();
 

--- a/src/http/handler_atprotocol_session.rs
+++ b/src/http/handler_atprotocol_session.rs
@@ -26,6 +26,8 @@ pub struct SessionQuery {
     pub access_token_type: String,
     /// Subject DID for app password session lookup (optional)
     pub sub: Option<String>,
+    /// DID of the account owner to act on behalf of (delegate access)
+    pub delegate_for: Option<String>,
 }
 
 fn default_access_token_type() -> String {
@@ -102,6 +104,44 @@ pub async fn get_atprotocol_session_handler(
             });
             (StatusCode::UNAUTHORIZED, Json(error_response))
         })?
+    };
+
+    // Handle delegate_for: if present, verify caller is a delegate and switch to owner's DID
+    let did = if let Some(ref owner_did) = query.delegate_for {
+        // Validate the DID format
+        if let Err(e) = super::utils_oauth::validate_did(owner_did) {
+            let error_response = json!({
+                "error": "invalid_request",
+                "error_description": format!("Invalid delegate_for DID: {}", e)
+            });
+            return Err((StatusCode::BAD_REQUEST, Json(error_response)));
+        }
+
+        // Verify the caller is a delegate for the requested owner
+        let is_delegate = state
+            .oauth_storage
+            .is_delegate(owner_did, did)
+            .await
+            .map_err(|e| {
+                let error_response = json!({
+                    "error": "server_error",
+                    "error_description": format!("Failed to check delegate access: {}", e)
+                });
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(error_response))
+            })?;
+
+        if !is_delegate {
+            let error_response = json!({
+                "error": "forbidden",
+                "error_description": "You are not a delegate for this account"
+            });
+            return Err((StatusCode::FORBIDDEN, Json(error_response)));
+        }
+
+        // Use the owner's DID for session lookup
+        owner_did
+    } else {
+        did
     };
 
     // Retrieve the DID document from DocumentStorage
@@ -182,6 +222,76 @@ pub async fn get_atprotocol_session_handler(
             Err(err) => {
                 tracing::warn!(?err, "no app-password session found");
                 // For "best" mode, continue to OAuth session below
+            }
+        }
+    }
+
+    // If delegate_for is set and we haven't returned yet, look up the owner's sessions by DID
+    if query.delegate_for.is_some() {
+        // For delegation, find the owner's latest session by DID
+        let owner_sessions = state
+            .oauth_storage
+            .get_sessions_by_did(did)
+            .await
+            .map_err(|e| {
+                let error_response = json!({
+                    "error": "server_error",
+                    "error_description": format!("Failed to look up owner sessions: {}", e)
+                });
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(error_response))
+            })?;
+
+        // Find the best session: prefer one with a valid access token
+        let best_session = owner_sessions
+            .iter()
+            .filter(|s| s.access_token.is_some() && s.session_exchanged_at.is_some() && s.exchange_error.is_none())
+            .max_by_key(|s| s.access_token_expires_at);
+
+        match best_session {
+            Some(session) => {
+                let (access_token_val, expires_at, scopes) = match (
+                    session.access_token.clone(),
+                    session.access_token_expires_at,
+                    session.access_token_scopes.clone(),
+                ) {
+                    (Some(at), Some(exp), Some(sc)) => (at, exp.timestamp(), sc),
+                    _ => {
+                        let error_response = json!({
+                            "error": "session_incomplete",
+                            "error_description": "Owner session found but is not valid"
+                        });
+                        return Err((StatusCode::INTERNAL_SERVER_ERROR, Json(error_response)));
+                    }
+                };
+
+                // Never return private key for delegated sessions — delegates must use
+                // the /api/atprotocol/dpop-proof endpoint for per-request signing
+                let dpop_key = None;
+                let dpop_jwk = None;
+
+                let response = AtpSessionResponse {
+                    did: document.id.clone(),
+                    handle: document.handles().unwrap_or("unknown.unknown").to_string(),
+                    access_token: access_token_val,
+                    token_type: "dpop".to_string(),
+                    scopes,
+                    pds_endpoint: document
+                        .pds_endpoints()
+                        .first()
+                        .map_or("", |v| v)
+                        .to_string(),
+                    dpop_key,
+                    dpop_jwk,
+                    expires_at,
+                };
+                return Ok(Json(response));
+            }
+            None => {
+                let error_response = json!({
+                    "error": "session_not_found",
+                    "error_description": "No valid session found for the delegated account"
+                });
+                return Err((StatusCode::NOT_FOUND, Json(error_response)));
             }
         }
     }

--- a/src/http/handler_delegate.rs
+++ b/src/http/handler_delegate.rs
@@ -1,0 +1,148 @@
+//! Handles delegate access management endpoints
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::Json,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::context::AppState;
+use super::utils_error::{StorageResultExt, bad_request, unauthorized};
+use super::utils_oauth::validate_did;
+use crate::http::middleware_auth::ExtractedAuth;
+
+/// Request body for grant/revoke operations
+#[derive(Debug, Deserialize)]
+pub struct DelegateBody {
+    pub delegate_did: String,
+}
+
+/// A delegate grant in API responses
+#[derive(Debug, Serialize)]
+pub struct DelegateGrantResponse {
+    pub owner_did: String,
+    pub delegate_did: String,
+    pub granted_at: String,
+}
+
+/// Grant delegate access
+/// POST /api/delegate/grant
+pub async fn grant_delegate_handler(
+    State(state): State<AppState>,
+    ExtractedAuth(access_token): ExtractedAuth,
+    Json(body): Json<DelegateBody>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let owner_did = access_token
+        .user_id
+        .as_ref()
+        .ok_or_else(|| unauthorized("Token missing user_id (DID)"))?;
+
+    if let Err(e) = validate_did(&body.delegate_did) {
+        return Err(bad_request(format!("Invalid delegate_did: {}", e)));
+    }
+
+    if owner_did == &body.delegate_did {
+        return Err(bad_request("Cannot delegate to yourself"));
+    }
+
+    state
+        .oauth_storage
+        .grant_delegate(owner_did, &body.delegate_did)
+        .await
+        .to_http_error("Failed to grant delegate access")?;
+
+    Ok(Json(json!({
+        "owner_did": owner_did,
+        "delegate_did": body.delegate_did,
+        "message": "Delegate access granted"
+    })))
+}
+
+/// Revoke delegate access
+/// POST /api/delegate/revoke
+pub async fn revoke_delegate_handler(
+    State(state): State<AppState>,
+    ExtractedAuth(access_token): ExtractedAuth,
+    Json(body): Json<DelegateBody>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let owner_did = access_token
+        .user_id
+        .as_ref()
+        .ok_or_else(|| unauthorized("Token missing user_id (DID)"))?;
+
+    if let Err(e) = validate_did(&body.delegate_did) {
+        return Err(bad_request(format!("Invalid delegate_did: {}", e)));
+    }
+
+    state
+        .oauth_storage
+        .revoke_delegate(owner_did, &body.delegate_did)
+        .await
+        .to_http_error("Failed to revoke delegate access")?;
+
+    Ok(Json(json!({
+        "owner_did": owner_did,
+        "delegate_did": body.delegate_did,
+        "message": "Delegate access revoked"
+    })))
+}
+
+/// List delegates for the authenticated user (as owner)
+/// GET /api/delegate/delegates
+pub async fn list_delegates_handler(
+    State(state): State<AppState>,
+    ExtractedAuth(access_token): ExtractedAuth,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let owner_did = access_token
+        .user_id
+        .as_ref()
+        .ok_or_else(|| unauthorized("Token missing user_id (DID)"))?;
+
+    let grants = state
+        .oauth_storage
+        .list_delegates(owner_did)
+        .await
+        .to_http_error("Failed to list delegates")?;
+
+    let response: Vec<DelegateGrantResponse> = grants
+        .into_iter()
+        .map(|g| DelegateGrantResponse {
+            owner_did: g.owner_did,
+            delegate_did: g.delegate_did,
+            granted_at: g.granted_at.to_rfc3339(),
+        })
+        .collect();
+
+    Ok(Json(json!({ "delegates": response })))
+}
+
+/// List owners the authenticated user is a delegate for
+/// GET /api/delegate/owners
+pub async fn list_owners_handler(
+    State(state): State<AppState>,
+    ExtractedAuth(access_token): ExtractedAuth,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let delegate_did = access_token
+        .user_id
+        .as_ref()
+        .ok_or_else(|| unauthorized("Token missing user_id (DID)"))?;
+
+    let grants = state
+        .oauth_storage
+        .list_owners(delegate_did)
+        .await
+        .to_http_error("Failed to list owners")?;
+
+    let response: Vec<DelegateGrantResponse> = grants
+        .into_iter()
+        .map(|g| DelegateGrantResponse {
+            owner_did: g.owner_did,
+            delegate_did: g.delegate_did,
+            granted_at: g.granted_at.to_rfc3339(),
+        })
+        .collect();
+
+    Ok(Json(json!({ "owners": response })))
+}

--- a/src/http/handler_dpop_proof.rs
+++ b/src/http/handler_dpop_proof.rs
@@ -1,0 +1,204 @@
+//! Handles POST /api/atprotocol/dpop-proof - Signs DPoP proofs for authenticated sessions
+//!
+//! Instead of returning the private key to delegates, AIP keeps the key and signs
+//! DPoP proofs on demand. This ensures revocation is immediate — every signing request
+//! re-checks delegation status.
+
+use atproto_identity::key::{identify_key, sign, to_public};
+use atproto_oauth::jwk::generate as generate_jwk;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::Json,
+};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+use super::context::AppState;
+use super::utils_error::{bad_request, server_error, unauthorized};
+use super::utils_oauth::validate_did;
+use crate::http::middleware_auth::ExtractedAuth;
+
+/// Request body for DPoP proof signing
+#[derive(Debug, Deserialize)]
+pub struct DpopProofRequest {
+    /// HTTP method for the DPoP proof (e.g. "POST", "GET")
+    pub method: String,
+    /// Target URL for the DPoP proof
+    pub url: String,
+    /// Owner DID to act on behalf of (optional, for delegate access)
+    pub delegate_for: Option<String>,
+    /// PDS-provided nonce for retry (optional)
+    pub nonce: Option<String>,
+}
+
+/// Response containing the signed DPoP proof
+#[derive(Debug, Serialize)]
+pub struct DpopProofResponse {
+    /// Signed DPoP proof JWT
+    pub dpop_proof: String,
+    /// DPoP-bound access token (useless without the proof)
+    pub access_token: String,
+}
+
+/// DPoP JWT claims
+#[derive(Debug, Serialize)]
+struct DPoPClaims {
+    jti: String,
+    htm: String,
+    htu: String,
+    iat: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ath: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<String>,
+}
+
+/// Sign a DPoP proof for an authenticated session
+/// POST /api/atprotocol/dpop-proof
+pub async fn dpop_proof_handler(
+    State(state): State<AppState>,
+    ExtractedAuth(access_token): ExtractedAuth,
+    Json(body): Json<DpopProofRequest>,
+) -> Result<Json<DpopProofResponse>, (StatusCode, Json<Value>)> {
+    // 1. Extract caller DID
+    let caller_did = access_token
+        .user_id
+        .as_ref()
+        .ok_or_else(|| unauthorized("Token missing user_id (DID)"))?;
+
+    // 2. Validate method and url
+    let method_upper = body.method.to_uppercase();
+    match method_upper.as_str() {
+        "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD" | "OPTIONS" => {}
+        _ => return Err(bad_request(format!("Invalid HTTP method: {}", body.method))),
+    }
+
+    if url::Url::parse(&body.url).is_err() {
+        return Err(bad_request(format!("Invalid URL: {}", body.url)));
+    }
+
+    // 3. If delegate_for is set, validate and check delegation
+    let target_did = if let Some(ref owner_did) = body.delegate_for {
+        if let Err(e) = validate_did(owner_did) {
+            return Err(bad_request(format!("Invalid delegate_for DID: {}", e)));
+        }
+
+        let is_delegate = state
+            .oauth_storage
+            .is_delegate(owner_did, caller_did)
+            .await
+            .map_err(|e| {
+                server_error(format!("Failed to check delegate access: {}", e))
+            })?;
+
+        if !is_delegate {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": "forbidden",
+                    "error_description": "You are not a delegate for this account"
+                })),
+            ));
+        }
+
+        owner_did.as_str()
+    } else {
+        caller_did.as_str()
+    };
+
+    // 4. Look up best session for target DID
+    let target_sessions = state
+        .oauth_storage
+        .get_sessions_by_did(target_did)
+        .await
+        .map_err(|e| {
+            server_error(format!("Failed to look up sessions: {}", e))
+        })?;
+
+    let session = target_sessions
+        .into_iter()
+        .filter(|s| {
+            s.access_token.is_some()
+                && s.session_exchanged_at.is_some()
+                && s.exchange_error.is_none()
+        })
+        .max_by_key(|s| s.access_token_expires_at)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({
+                    "error": "session_not_found",
+                    "error_description": "No valid session found"
+                })),
+            )
+        })?;
+
+    // Get the access token from the session
+    let session_access_token = session.access_token.as_ref().ok_or_else(|| {
+        server_error("Session has no access token")
+    })?;
+
+    // 5. Parse session.dpop_key via identify_key
+    let private_key_data = identify_key(&session.dpop_key)
+        .map_err(|e| server_error(format!("Failed to parse DPoP key: {}", e)))?;
+
+    // 6. Generate public JWK for JWT header
+    let public_key_data = to_public(&private_key_data)
+        .map_err(|e| server_error(format!("Failed to derive public key: {}", e)))?;
+    let jwk_wrapped = generate_jwk(&public_key_data)
+        .map_err(|e| server_error(format!("Failed to generate JWK: {}", e)))?;
+    let public_key_jwk: serde_json::Value = serde_json::to_value(&jwk_wrapped)
+        .map_err(|e| server_error(format!("Failed to serialize JWK: {}", e)))?;
+
+    // 7. Build DPoP proof JWT
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| server_error(format!("System time error: {}", e)))?
+        .as_secs();
+
+    let token_hash = Sha256::digest(session_access_token.as_bytes());
+    let ath = URL_SAFE_NO_PAD.encode(&token_hash);
+
+    let claims = DPoPClaims {
+        jti: Uuid::new_v4().to_string(),
+        htm: method_upper,
+        htu: body.url,
+        iat: now,
+        ath: Some(ath),
+        nonce: body.nonce,
+    };
+
+    let header_json = json!({
+        "typ": "dpop+jwt",
+        "alg": "ES256",
+        "jwk": public_key_jwk
+    });
+
+    let header_b64 = URL_SAFE_NO_PAD.encode(
+        serde_json::to_string(&header_json)
+            .map_err(|e| server_error(format!("Failed to serialize header: {}", e)))?,
+    );
+    let claims_b64 = URL_SAFE_NO_PAD.encode(
+        serde_json::to_string(&claims)
+            .map_err(|e| server_error(format!("Failed to serialize claims: {}", e)))?,
+    );
+
+    let signing_input = format!("{}.{}", header_b64, claims_b64);
+
+    let signature = sign(&private_key_data, signing_input.as_bytes())
+        .map_err(|e| server_error(format!("Failed to sign DPoP proof: {}", e)))?;
+    let signature_b64 = URL_SAFE_NO_PAD.encode(&signature);
+
+    let dpop_proof = format!("{}.{}", signing_input, signature_b64);
+
+    // 8. Return proof and access token
+    Ok(Json(DpopProofResponse {
+        dpop_proof,
+        access_token: session_access_token.clone(),
+    }))
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -7,6 +7,8 @@ mod handler_atprotocol_client_metadata;
 mod handler_atprotocol_oauth_authorize;
 mod handler_atprotocol_oauth_callback;
 mod handler_atprotocol_session;
+mod handler_delegate;
+mod handler_dpop_proof;
 mod handler_device_authorization;
 mod handler_device_code;
 

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -18,6 +18,11 @@ use super::{
     handler_atprotocol_oauth_authorize::handle_oauth_authorize,
     handler_atprotocol_oauth_callback::handle_atpoauth_callback,
     handler_atprotocol_session::get_atprotocol_session_handler,
+    handler_delegate::{
+        grant_delegate_handler, list_delegates_handler, list_owners_handler,
+        revoke_delegate_handler,
+    },
+    handler_dpop_proof::dpop_proof_handler,
     handler_device_authorization::{
         device_authorization_page, device_authorize, device_oauth_callback,
     },
@@ -48,6 +53,11 @@ pub fn build_router(ctx: AppState) -> Router {
             "/atprotocol/app-password",
             post(create_app_password_handler).get(get_app_password_handler),
         )
+        .route("/delegate/grant", post(grant_delegate_handler))
+        .route("/delegate/revoke", post(revoke_delegate_handler))
+        .route("/delegate/delegates", get(list_delegates_handler))
+        .route("/delegate/owners", get(list_owners_handler))
+        .route("/atprotocol/dpop-proof", post(dpop_proof_handler))
         .layer(middleware::map_response_with_state(
             ctx.clone(),
             set_dpop_headers,

--- a/src/http/utils_oauth.rs
+++ b/src/http/utils_oauth.rs
@@ -130,6 +130,28 @@ pub fn normalize_login_hint_typed(login_hint: &str) -> Result<LoginHintType, OAu
     normalize_as_handle(authority)
 }
 
+/// Validate that a string is a properly formatted DID (did:plc: or did:web:)
+///
+/// Returns Ok(()) if valid, or a human-readable error string if not.
+pub fn validate_did(did: &str) -> Result<(), String> {
+    let trimmed = did.trim();
+    if trimmed.is_empty() {
+        return Err("DID cannot be empty".to_string());
+    }
+    if trimmed.starts_with("did:plc:") {
+        if !is_valid_did_method_plc(trimmed) {
+            return Err("Invalid did:plc format".to_string());
+        }
+    } else if trimmed.starts_with("did:web:") {
+        if !is_valid_did_method_web(trimmed, true) {
+            return Err("Invalid did:web format".to_string());
+        }
+    } else {
+        return Err("Unsupported DID method (expected did:plc: or did:web:)".to_string());
+    }
+    Ok(())
+}
+
 /// Normalize a string as a DID
 fn normalize_as_did(did: &str) -> Result<LoginHintType, OAuthError> {
     if did.starts_with("did:plc:") {

--- a/src/storage/inmemory/oauth.rs
+++ b/src/storage/inmemory/oauth.rs
@@ -33,6 +33,8 @@ pub struct MemoryOAuthStorage {
     // App password storage
     app_passwords: tokio::sync::RwLock<HashMap<String, AppPassword>>, // "client_id:did" -> AppPassword
     app_password_sessions: tokio::sync::RwLock<HashMap<String, AppPasswordSession>>, // "client_id:did" -> AppPasswordSession
+    // Delegate access storage
+    delegate_grants: tokio::sync::RwLock<HashMap<String, DelegateGrant>>, // "owner_did:delegate_did" -> DelegateGrant
 }
 
 impl MemoryOAuthStorage {
@@ -53,6 +55,11 @@ impl MemoryOAuthStorage {
     /// Generate a unique app password key from client_id and DID
     fn app_password_key(client_id: &str, did: &str) -> String {
         format!("{}:{}", client_id, did)
+    }
+
+    /// Generate a unique delegate grant key from owner_did and delegate_did
+    fn delegate_key(owner_did: &str, delegate_did: &str) -> String {
+        format!("{}:{}", owner_did, delegate_did)
     }
 }
 
@@ -871,6 +878,53 @@ impl AppPasswordSessionStore for MemoryOAuthStorage {
         let result: Vec<_> = sessions
             .values()
             .filter(|s| s.client_id == client_id)
+            .cloned()
+            .collect();
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl DelegateAccessStore for MemoryOAuthStorage {
+    async fn grant_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        let mut grants = self.delegate_grants.write().await;
+        let key = Self::delegate_key(owner_did, delegate_did);
+        grants.entry(key).or_insert_with(|| DelegateGrant {
+            owner_did: owner_did.to_string(),
+            delegate_did: delegate_did.to_string(),
+            granted_at: Utc::now(),
+        });
+        Ok(())
+    }
+
+    async fn revoke_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        let mut grants = self.delegate_grants.write().await;
+        let key = Self::delegate_key(owner_did, delegate_did);
+        grants.remove(&key);
+        Ok(())
+    }
+
+    async fn is_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<bool> {
+        let grants = self.delegate_grants.read().await;
+        let key = Self::delegate_key(owner_did, delegate_did);
+        Ok(grants.contains_key(&key))
+    }
+
+    async fn list_delegates(&self, owner_did: &str) -> Result<Vec<DelegateGrant>> {
+        let grants = self.delegate_grants.read().await;
+        let result: Vec<_> = grants
+            .values()
+            .filter(|g| g.owner_did == owner_did)
+            .cloned()
+            .collect();
+        Ok(result)
+    }
+
+    async fn list_owners(&self, delegate_did: &str) -> Result<Vec<DelegateGrant>> {
+        let grants = self.delegate_grants.read().await;
+        let result: Vec<_> = grants
+            .values()
+            .filter(|g| g.delegate_did == delegate_did)
             .cloned()
             .collect();
         Ok(result)

--- a/src/storage/postgres/delegate_access.rs
+++ b/src/storage/postgres/delegate_access.rs
@@ -1,0 +1,140 @@
+//! PostgreSQL implementation for delegate access storage
+
+use crate::errors::StorageError;
+use crate::storage::traits::{DelegateAccessStore, DelegateGrant};
+use async_trait::async_trait;
+use chrono::Utc;
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgRow};
+
+pub type Result<T> = std::result::Result<T, StorageError>;
+
+/// PostgreSQL implementation for delegate access storage
+pub struct PostgresDelegateAccessStore {
+    pool: PgPool,
+}
+
+impl PostgresDelegateAccessStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Convert PostgreSQL row to DelegateGrant
+    fn row_to_delegate_grant(row: &PgRow) -> Result<DelegateGrant> {
+        Ok(DelegateGrant {
+            owner_did: row.try_get("owner_did").map_err(|e| {
+                StorageError::DatabaseError(format!("Failed to get owner_did: {}", e))
+            })?,
+            delegate_did: row.try_get("delegate_did").map_err(|e| {
+                StorageError::DatabaseError(format!("Failed to get delegate_did: {}", e))
+            })?,
+            granted_at: row.try_get("granted_at").map_err(|e| {
+                StorageError::DatabaseError(format!("Failed to get granted_at: {}", e))
+            })?,
+        })
+    }
+}
+
+#[async_trait]
+impl DelegateAccessStore for PostgresDelegateAccessStore {
+    async fn grant_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        let now = Utc::now();
+        sqlx::query(
+            r#"
+            INSERT INTO delegate_access (owner_did, delegate_did, granted_at)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (owner_did, delegate_did) DO NOTHING
+            "#,
+        )
+        .bind(owner_did)
+        .bind(delegate_did)
+        .bind(now)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StorageError::DatabaseError(format!("Failed to grant delegate: {}", e)))?;
+
+        Ok(())
+    }
+
+    async fn revoke_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM delegate_access
+            WHERE owner_did = $1 AND delegate_did = $2
+            "#,
+        )
+        .bind(owner_did)
+        .bind(delegate_did)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StorageError::DatabaseError(format!("Failed to revoke delegate: {}", e)))?;
+
+        Ok(())
+    }
+
+    async fn is_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<bool> {
+        let row = sqlx::query(
+            r#"
+            SELECT 1 FROM delegate_access
+            WHERE owner_did = $1 AND delegate_did = $2
+            "#,
+        )
+        .bind(owner_did)
+        .bind(delegate_did)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            StorageError::DatabaseError(format!("Failed to check delegate: {}", e))
+        })?;
+
+        Ok(row.is_some())
+    }
+
+    async fn list_delegates(&self, owner_did: &str) -> Result<Vec<DelegateGrant>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT owner_did, delegate_did, granted_at
+            FROM delegate_access
+            WHERE owner_did = $1
+            ORDER BY granted_at DESC
+            "#,
+        )
+        .bind(owner_did)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            StorageError::DatabaseError(format!("Failed to list delegates: {}", e))
+        })?;
+
+        let mut grants = Vec::new();
+        for row in rows {
+            grants.push(Self::row_to_delegate_grant(&row)?);
+        }
+
+        Ok(grants)
+    }
+
+    async fn list_owners(&self, delegate_did: &str) -> Result<Vec<DelegateGrant>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT owner_did, delegate_did, granted_at
+            FROM delegate_access
+            WHERE delegate_did = $1
+            ORDER BY granted_at DESC
+            "#,
+        )
+        .bind(delegate_did)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            StorageError::DatabaseError(format!("Failed to list owners: {}", e))
+        })?;
+
+        let mut grants = Vec::new();
+        for row in rows {
+            grants.push(Self::row_to_delegate_grant(&row)?);
+        }
+
+        Ok(grants)
+    }
+}

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -8,6 +8,7 @@ mod app_passwords;
 mod atp_oauth_sessions;
 mod authorization_codes;
 mod authorization_requests;
+mod delegate_access;
 mod device_codes;
 mod did_documents;
 mod keys;
@@ -27,6 +28,7 @@ pub use app_passwords::{PostgresAppPasswordSessionStore, PostgresAppPasswordStor
 pub use atp_oauth_sessions::PostgresAtpOAuthSessionStorage;
 pub use authorization_codes::PostgresAuthorizationCodeStore;
 pub use authorization_requests::PostgresAuthorizationRequestStorage;
+pub use delegate_access::PostgresDelegateAccessStore;
 pub use device_codes::PostgresDeviceCodeStore;
 pub use did_documents::PostgresDidDocumentStorage;
 pub use keys::PostgresKeyStore;
@@ -53,6 +55,7 @@ pub struct PostgresOAuthStorage {
     oauth_request_storage: Arc<PostgresOAuthRequestStorage>,
     app_password_store: Arc<PostgresAppPasswordStore>,
     app_password_session_store: Arc<PostgresAppPasswordSessionStore>,
+    delegate_access_store: Arc<PostgresDelegateAccessStore>,
 }
 
 impl PostgresOAuthStorage {
@@ -73,6 +76,7 @@ impl PostgresOAuthStorage {
         let app_password_store = Arc::new(PostgresAppPasswordStore::new(pool.clone()));
         let app_password_session_store =
             Arc::new(PostgresAppPasswordSessionStore::new(pool.clone()));
+        let delegate_access_store = Arc::new(PostgresDelegateAccessStore::new(pool.clone()));
 
         Self {
             pool,
@@ -89,6 +93,7 @@ impl PostgresOAuthStorage {
             oauth_request_storage,
             app_password_store,
             app_password_session_store,
+            delegate_access_store,
         }
     }
 
@@ -562,6 +567,35 @@ impl AppPasswordSessionStore for PostgresOAuthStorage {
         self.app_password_session_store
             .list_app_password_sessions_by_client(client_id)
             .await
+    }
+}
+
+#[async_trait]
+impl DelegateAccessStore for PostgresOAuthStorage {
+    async fn grant_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        self.delegate_access_store
+            .grant_delegate(owner_did, delegate_did)
+            .await
+    }
+
+    async fn revoke_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        self.delegate_access_store
+            .revoke_delegate(owner_did, delegate_did)
+            .await
+    }
+
+    async fn is_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<bool> {
+        self.delegate_access_store
+            .is_delegate(owner_did, delegate_did)
+            .await
+    }
+
+    async fn list_delegates(&self, owner_did: &str) -> Result<Vec<DelegateGrant>> {
+        self.delegate_access_store.list_delegates(owner_did).await
+    }
+
+    async fn list_owners(&self, delegate_did: &str) -> Result<Vec<DelegateGrant>> {
+        self.delegate_access_store.list_owners(delegate_did).await
     }
 }
 

--- a/src/storage/sqlite/delegate_access.rs
+++ b/src/storage/sqlite/delegate_access.rs
@@ -1,0 +1,145 @@
+//! SQLite implementation for delegate access storage
+
+use crate::errors::StorageError;
+use crate::storage::traits::{DelegateAccessStore, DelegateGrant};
+use async_trait::async_trait;
+use chrono::Utc;
+use sqlx::Row;
+use sqlx::sqlite::{SqlitePool, SqliteRow};
+
+pub type Result<T> = std::result::Result<T, StorageError>;
+
+/// SQLite implementation for delegate access storage
+pub struct SqliteDelegateAccessStore {
+    pool: SqlitePool,
+}
+
+impl SqliteDelegateAccessStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Convert SQLite row to DelegateGrant
+    fn row_to_delegate_grant(row: &SqliteRow) -> Result<DelegateGrant> {
+        let granted_at_str: String = row
+            .try_get("granted_at")
+            .map_err(|e| StorageError::DatabaseError(format!("Failed to get granted_at: {}", e)))?;
+        let granted_at = chrono::DateTime::parse_from_rfc3339(&granted_at_str)
+            .map_err(|e| StorageError::SerializationFailed(format!("Invalid granted_at: {}", e)))?
+            .with_timezone(&Utc);
+
+        Ok(DelegateGrant {
+            owner_did: row.try_get("owner_did").map_err(|e| {
+                StorageError::DatabaseError(format!("Failed to get owner_did: {}", e))
+            })?,
+            delegate_did: row.try_get("delegate_did").map_err(|e| {
+                StorageError::DatabaseError(format!("Failed to get delegate_did: {}", e))
+            })?,
+            granted_at,
+        })
+    }
+}
+
+#[async_trait]
+impl DelegateAccessStore for SqliteDelegateAccessStore {
+    async fn grant_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"
+            INSERT INTO delegate_access (owner_did, delegate_did, granted_at)
+            VALUES (?1, ?2, ?3)
+            ON CONFLICT (owner_did, delegate_did) DO NOTHING
+            "#,
+        )
+        .bind(owner_did)
+        .bind(delegate_did)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StorageError::DatabaseError(format!("Failed to grant delegate: {}", e)))?;
+
+        Ok(())
+    }
+
+    async fn revoke_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM delegate_access
+            WHERE owner_did = ?1 AND delegate_did = ?2
+            "#,
+        )
+        .bind(owner_did)
+        .bind(delegate_did)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StorageError::DatabaseError(format!("Failed to revoke delegate: {}", e)))?;
+
+        Ok(())
+    }
+
+    async fn is_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<bool> {
+        let row = sqlx::query(
+            r#"
+            SELECT 1 FROM delegate_access
+            WHERE owner_did = ?1 AND delegate_did = ?2
+            "#,
+        )
+        .bind(owner_did)
+        .bind(delegate_did)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            StorageError::DatabaseError(format!("Failed to check delegate: {}", e))
+        })?;
+
+        Ok(row.is_some())
+    }
+
+    async fn list_delegates(&self, owner_did: &str) -> Result<Vec<DelegateGrant>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT owner_did, delegate_did, granted_at
+            FROM delegate_access
+            WHERE owner_did = ?1
+            ORDER BY granted_at DESC
+            "#,
+        )
+        .bind(owner_did)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            StorageError::DatabaseError(format!("Failed to list delegates: {}", e))
+        })?;
+
+        let mut grants = Vec::new();
+        for row in rows {
+            grants.push(Self::row_to_delegate_grant(&row)?);
+        }
+
+        Ok(grants)
+    }
+
+    async fn list_owners(&self, delegate_did: &str) -> Result<Vec<DelegateGrant>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT owner_did, delegate_did, granted_at
+            FROM delegate_access
+            WHERE delegate_did = ?1
+            ORDER BY granted_at DESC
+            "#,
+        )
+        .bind(delegate_did)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            StorageError::DatabaseError(format!("Failed to list owners: {}", e))
+        })?;
+
+        let mut grants = Vec::new();
+        for row in rows {
+            grants.push(Self::row_to_delegate_grant(&row)?);
+        }
+
+        Ok(grants)
+    }
+}

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -8,6 +8,7 @@ mod app_passwords;
 mod atp_oauth_sessions;
 mod authorization_codes;
 mod authorization_requests;
+mod delegate_access;
 mod device_codes;
 mod keys;
 mod oauth_clients;
@@ -26,6 +27,7 @@ pub use app_passwords::{SqliteAppPasswordSessionStore, SqliteAppPasswordStore};
 pub use atp_oauth_sessions::SqliteAtpOAuthSessionStorage;
 pub use authorization_codes::SqliteAuthorizationCodeStore;
 pub use authorization_requests::SqliteAuthorizationRequestStorage;
+pub use delegate_access::SqliteDelegateAccessStore;
 pub use device_codes::SqliteDeviceCodeStore;
 pub use keys::SqliteKeyStore;
 pub use oauth_clients::SqliteOAuthClientStore;
@@ -49,6 +51,7 @@ pub struct SqliteOAuthStorage {
     authorization_request_storage: Arc<SqliteAuthorizationRequestStorage>,
     app_password_store: Arc<SqliteAppPasswordStore>,
     app_password_session_store: Arc<SqliteAppPasswordSessionStore>,
+    delegate_access_store: Arc<SqliteDelegateAccessStore>,
 }
 
 impl SqliteOAuthStorage {
@@ -66,6 +69,7 @@ impl SqliteOAuthStorage {
             Arc::new(SqliteAuthorizationRequestStorage::new(pool.clone()));
         let app_password_store = Arc::new(SqliteAppPasswordStore::new(pool.clone()));
         let app_password_session_store = Arc::new(SqliteAppPasswordSessionStore::new(pool.clone()));
+        let delegate_access_store = Arc::new(SqliteDelegateAccessStore::new(pool.clone()));
 
         Self {
             pool,
@@ -80,6 +84,7 @@ impl SqliteOAuthStorage {
             authorization_request_storage,
             app_password_store,
             app_password_session_store,
+            delegate_access_store,
         }
     }
 
@@ -489,6 +494,35 @@ impl AppPasswordSessionStore for SqliteOAuthStorage {
         self.app_password_session_store
             .list_app_password_sessions_by_client(client_id)
             .await
+    }
+}
+
+#[async_trait]
+impl DelegateAccessStore for SqliteOAuthStorage {
+    async fn grant_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        self.delegate_access_store
+            .grant_delegate(owner_did, delegate_did)
+            .await
+    }
+
+    async fn revoke_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()> {
+        self.delegate_access_store
+            .revoke_delegate(owner_did, delegate_did)
+            .await
+    }
+
+    async fn is_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<bool> {
+        self.delegate_access_store
+            .is_delegate(owner_did, delegate_did)
+            .await
+    }
+
+    async fn list_delegates(&self, owner_did: &str) -> Result<Vec<DelegateGrant>> {
+        self.delegate_access_store.list_delegates(owner_did).await
+    }
+
+    async fn list_owners(&self, delegate_did: &str) -> Result<Vec<DelegateGrant>> {
+        self.delegate_access_store.list_owners(delegate_did).await
     }
 }
 

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -397,6 +397,39 @@ pub trait AppPasswordSessionStore: Send + Sync {
     ) -> Result<Vec<AppPasswordSession>>;
 }
 
+// ===== Delegate Access Storage Traits =====
+
+/// A grant allowing one DID to act on behalf of another
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(any(debug_assertions, test), derive(Debug))]
+pub struct DelegateGrant {
+    /// The DID of the account owner who grants access
+    pub owner_did: String,
+    /// The DID of the delegate who receives access
+    pub delegate_did: String,
+    /// When the delegation was granted
+    pub granted_at: DateTime<Utc>,
+}
+
+/// Trait for storing and managing delegate access grants
+#[async_trait]
+pub trait DelegateAccessStore: Send + Sync {
+    /// Grant delegate access from owner to delegate
+    async fn grant_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()>;
+
+    /// Revoke delegate access from owner to delegate
+    async fn revoke_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<()>;
+
+    /// Check if delegate_did is a delegate for owner_did
+    async fn is_delegate(&self, owner_did: &str, delegate_did: &str) -> Result<bool>;
+
+    /// List all delegates for an owner
+    async fn list_delegates(&self, owner_did: &str) -> Result<Vec<DelegateGrant>>;
+
+    /// List all owners that a delegate has access to
+    async fn list_owners(&self, delegate_did: &str) -> Result<Vec<DelegateGrant>>;
+}
+
 // ===== Combined Storage Trait =====
 
 /// Combined OAuth storage trait
@@ -412,6 +445,7 @@ pub trait OAuthStorage:
     + AuthorizationRequestStorage
     + AppPasswordStore
     + AppPasswordSessionStore
+    + DelegateAccessStore
     + Send
     + Sync
 {


### PR DESCRIPTION
## Summary
- Bind to `[::]` instead of `0.0.0.0` so the server listens on both IPv4 and IPv6
- Enables Railway private networking which uses IPv6 for inter-service communication

## Test plan
- [ ] Verify server starts and accepts connections on IPv4
- [ ] Verify server is reachable via IPv6 (e.g. Railway private networking)